### PR TITLE
[NPE Exit] Close button not always showing (fix #44)

### DIFF
--- a/src/pages/Content/modules/set-npe-exit.ts
+++ b/src/pages/Content/modules/set-npe-exit.ts
@@ -1,45 +1,61 @@
+import debounce from 'debounce';
+import 'arrive'
+
 import { NPE_EXIT, q, waitForElement } from '../lib';
 
-const run = async (value = null) => {
-  const result = await chrome.storage.local.get([NPE_EXIT]);
-  const isEnabled = value ? value : result[NPE_EXIT] || false;
+const removeButton = () => {
+  const closeButtonEl = q<HTMLLinkElement>('#npe-exit-button');
+  if (closeButtonEl) {
+    closeButtonEl.parentNode?.removeChild(closeButtonEl)
+  }
+}
+
+const appendButton = async () => {
+  let closeButtonEl = q<HTMLLinkElement>('#npe-exit-button');
+  if (closeButtonEl) {
+    return
+  }
+
+  closeButtonEl = document.createElement('a') as unknown as HTMLLinkElement;
+  closeButtonEl.id = 'npe-exit-button';
+  closeButtonEl.href = '/dashboard';
+  closeButtonEl.innerHTML = '⨯';
+  closeButtonEl.title = 'Close the NPE';
+  closeButtonEl.className = 'npe-exit-button';
+
   const proposalHeaderEl = await waitForElement<HTMLDivElement>(
     '[data-testid="proposal-header"]'
   );
-
-  if (!proposalHeaderEl) {
-    return;
+  if (proposalHeaderEl?.firstChild) {
+    (proposalHeaderEl.firstChild as HTMLElement).prepend(closeButtonEl);
   }
+}
 
-  let closeButtonEl = q<HTMLLinkElement>('#npe-exit-button');
-  if (isEnabled && !closeButtonEl) {
-    const closeButtonEl = document.createElement('a');
-    closeButtonEl.id = 'npe-exit-button';
-    closeButtonEl.href = '/dashboard';
-    closeButtonEl.innerHTML = '⨯';
-    closeButtonEl.title = 'Close the NPE';
-    closeButtonEl.className = 'npe-exit-button';
-    if (proposalHeaderEl.firstChild) {
-      (proposalHeaderEl.firstChild as HTMLElement).prepend(closeButtonEl);
-    }
+const run = async (isEnabled: boolean) => {
+  if (isEnabled) {
+    appendButton()
   } else {
-    if (closeButtonEl) {
-      closeButtonEl.parentNode?.removeChild(closeButtonEl);
-    }
+    removeButton()
   }
-};
+}
 
 export const setNpeExit = () => {
   chrome.runtime.onMessage.addListener(async ({ type }) => {
-    if (type === NPE_EXIT) {
-      await run();
+    if (type !== NPE_EXIT) {
+      return
     }
+
+    const result = await chrome.storage.local.get([NPE_EXIT]);
+    const isEnabled = !!result[NPE_EXIT];
+    await run(isEnabled)
   });
 
   chrome.storage.local.onChanged.addListener(async (changes) => {
-    const featureFlags = Object.keys(changes);
-    if (featureFlags.includes(NPE_EXIT)) {
-      await run(changes[NPE_EXIT].newValue);
+    if (!changes[NPE_EXIT]) {
+      return
     }
+
+    const isEnabled = !!changes[NPE_EXIT].newValue
+    await run(isEnabled)
   });
 };


### PR DESCRIPTION
## What

NPE-44 [Bugfix] Close button not always showing

## Why

- The close button for the NPE (New Product Experience) exit was not consistently appearing, causing user frustration and navigation issues.

## How

- Added debounce to `handleLoadPage` to prevent multiple rapid calls.
- Introduced `handleLoadPageDebounced` to replace direct calls to `handleLoadPage`.
- Updated the logic to check if the NPE exit feature is enabled before sending messages.
- Refactored the button handling logic into separate `appendButton` and `removeButton` functions for better readability and maintainability.
- Ensured the close button is appended or removed based on the feature flag status.
- Added event listeners to handle changes in the NPE exit feature flag and update the button accordingly.

## Before

## After