### PR TITLE
[NPE Exit] Fix: Multiple buttons showing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ignitionapp-toolbelt",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "A chrome extension boilerplate built with React 17, Webpack 5, and Webpack Dev Server 4",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## What

NPE-123 [NPE Exit] Fix: Multiple buttons showing

## Why

- The NPE Exit button was being appended multiple times due to rapid state changes.
- This fix ensures that the button is appended only once, preventing UI clutter and potential user confusion.

## How

- Introduced a `isWaiting` flag to prevent multiple simultaneous executions of the `appendButton` function.
- Added a debounce mechanism to the `run` function to limit the frequency of its execution.
- Updated the version in `package.json` to `0.3.4`.

## Before

## After